### PR TITLE
Update wallet.js

### DIFF
--- a/assets/js/webapp/wallet.js
+++ b/assets/js/webapp/wallet.js
@@ -261,11 +261,12 @@ window.getPhantomSDK = getPhantomSDK;
 // ====================== LOAD LISTENER - SINGLE SOURCE OF TRUTH ======================
 window.addEventListener('load', async () => {
     const urlParams = new URLSearchParams(window.location.search);
+    
+    await getPhantomSDK();
 
     // 1. Handle OAuth Handshake
     if (urlParams.get('code')) {
         console.log("⚠️ OAuth callback detected — Initializing SDK handshake");
-        await getPhantomSDK();
         return; // The 'connect' listener in getPhantomSDK will handle the UI update
     }
 


### PR DESCRIPTION
Moved await getPhantomSDK(); to the top of the window load listener, right after the URL parameters are defined. This makes sure the SDK is fully initialized before any other logic (like OAuth or memory recall) runs, which should resolve auto connection issues and fix state persistence across pages.